### PR TITLE
Created App.jsx skeleton, added configuration option to webpack

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <>
+        <span>Hello, world!</span>
+        {/* <Overview />
+        <RelatedItemsAndComparison />
+        <QuestionsAndAnswers />
+        <RatingsAndReviews /> */}
+      </>
+    );
+  }
+}
+
+export default App;

--- a/client/index.js
+++ b/client/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import App from './components/App';
 
-ReactDOM.render(<div>Hello, world!</div>, document.getElementById('app'));
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,9 @@ const path = require('path');
 module.exports = {
   entry: './client/index.js',
   mode: 'development',
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'public'),


### PR DESCRIPTION
The linter did not like when I left the file extension in the import statement for App, so I added a statement to the webpack config file that allowed it to automatically check for .jsx files in lieu of a specified file extension. Seems to be working. We now have a place to render our individual widgets.